### PR TITLE
Make prove6 bin script more portable

### DIFF
--- a/bin/prove6
+++ b/bin/prove6
@@ -1,4 +1,4 @@
-#! perl6
+#!/usr/bin/env raku
 
 use App::Prove6 :MAIN;
 


### PR DESCRIPTION
This PR adds a more portable shebang line to bin/prove6 and sets the file to executable.  This conforms to how other bin scripts in the Raku ecosystem are written (for example, bin/zef).