### PR TITLE
Matrix strategy in github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           raku-version: ${{ matrix.raku-version }}
       - name: Install
-        run: zef --verbose install .
+        run: zef --debug install .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+name: test
+
 on: [push, pull_request, workflow_dispatch]
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,21 @@
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   raku:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        raku-version:
+          - 'latest'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: Raku/setup-raku@v1
-
+        with:
+          raku-version: ${{ matrix.raku-version }}
       - name: Install
-        run: zef install .
+        run: zef --verbose install .
 


### PR DESCRIPTION
I like to update a Module (Benchmark) which uses prove6 as dependency but tests on Linux, Mac and Windows. Windows-Build fails (see Error in Action) - would be good to have prove6 also install under Windows, I guess. Please have a look at the error message of the windows [build.](https://github.com/rcmlz/app-prove6/actions/runs/6440528777/job/17489441640)